### PR TITLE
bump argo-cd to 2.1.2

### DIFF
--- a/docs/chapter0.md
+++ b/docs/chapter0.md
@@ -240,7 +240,7 @@ Argo CD専用のCLIをインストールします。
 
 任意のディレクトリにこのexeファイルを格納して、パスを通します。
 
-https://github.com/argoproj/argo-cd/releases/download/v2.0.5/argocd-windows-amd64.exe
+https://github.com/argoproj/argo-cd/releases/download/v2.1.2/argocd-windows-amd64.exe
 
 パス設定参考サイト:
 https://www.atmarkit.co.jp/ait/articles/1805/11/news035.html
@@ -257,7 +257,7 @@ Cloud Shellから接続を抜けても継続してargocdコマンドを実行で
 
 ```bash
 $ mkdir -p ~/argocd/bin
-$ sudo curl -sSL -o ~/argocd/bin/argocd https://github.com/argoproj/argo-cd/releases/download/v2.0.5/argocd-linux-amd64
+$ sudo curl -sSL -o ~/argocd/bin/argocd https://github.com/argoproj/argo-cd/releases/download/v2.1.2/argocd-linux-amd64
 ```
 
 ```bash

--- a/docs/chapter8.md
+++ b/docs/chapter8.md
@@ -18,8 +18,7 @@ namespace/argocd created
 Argo CDをインストールします。
 
 ```bash
-# 現時点での最新はv2.1.1ですが、動作確認はv2.0.5で行っています
-$ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/v2.0.5/manifests/install.yaml
+$ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/v2.1.2/manifests/install.yaml
 ```
 
 以下のPodがRunningになっていることを確認します。


### PR DESCRIPTION
- Argo CD を最新の 2.1.2 に (ref: #89 )
- 出力結果や動作は前と変わらず

## notice

@cyberblack28  chapter0 の Argo の部分はこちらでやっちゃいましたが大丈夫でしょうか？
